### PR TITLE
Add installation instructions for jupyter and jupyterlab

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ For a development installation (requires yarn and JupyterLab 3),
 ```
 $ git clone https://github.com/QuantStack/ipytree.git
 $ cd ipytree
+$ pip install jupyter
+$ pip install "jupyterlab>=3.0.0,<4.0.0"
 $ pip install -e .
 $ jupyter nbextension install --py --symlink --sys-prefix ipytree
 $ jupyter nbextension enable --py --sys-prefix ipytree


### PR DESCRIPTION
We're limiting the version range in `pip install "jupyterlab>=3.0.0,<4.0.0"`, as I'm getting the following error message if I simply run `pip install jupyterlab` to get the latest version:

```
$ jupyter nbextension install --py --symlink --sys-prefix ipytree
usage: jupyter [-h] [--version] [--config-dir] [--data-dir] [--runtime-dir] [--paths] [--json]
[...]

Jupyter command `jupyter-nbextension` not found.
```